### PR TITLE
Fixed format specifier error while compile

### DIFF
--- a/healthd/healthd_mode_charger.cpp
+++ b/healthd/healthd_mode_charger.cpp
@@ -263,7 +263,7 @@ static int set_tricolor_led(int on, int color)
         if ((color & leds[i].color) && (access(leds[i].path, R_OK | W_OK) == 0)) {
             fd = open(leds[i].path, O_RDWR);
             if (fd < 0) {
-                LOGE("Could not open led node %d\n", i);
+                LOGE("Could not open led node %zu\n", i);
                 continue;
             }
             if (on)


### PR DESCRIPTION
system/core/healthd/healthd_mode_charger.cpp:266:54: error: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Werror,-Wformat]
                LOGE("Could not open led node %d\n", i);
                                              ~~     ^
                                              %zu